### PR TITLE
cartage-remote 1.1

### DIFF
--- a/History.rdoc
+++ b/History.rdoc
@@ -1,4 +1,26 @@
-=== 1.0 / 2015-03-20
+=== 1.1 / 2015-03-26
+
+*   1 major bugfix
+
+    *   When a remote script fails, the error would not result in a non-zero
+        exit code, meaning that scripts could not detect failures in cartage
+        remote. Fixes [#1]{https://github.com/KineticCafe/cartage/issues/1}.
+
+*   1 minor enhancement
+
+    *   When the build is interrupted and a postbuild script is to be run, it
+        will be passed the exception error message as well as the stage.
+
+*   1 minor bugfix
+
+    *   Ensured that the last stage is not +cleanup+; added a +finished+ stage.
+
+*   Internal changes:
+
+    *   Using [micromachine]{https://github.com/soveran/micromachine} to
+        provide the remote builds state machine cleanly.
+
+=== 1.0 / 2015-03-24
 
 *   1 major enhancement
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -24,7 +24,7 @@ control rules and without requiring development tool access.
 
 Add cartage-remote to your Gemfile:
 
-    gem 'cartage-remote', '~> 1.0'
+    gem 'cartage-remote', '~> 1.1'
 
 Or manually install:
 

--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,8 @@ spec = Hoe.spec 'cartage-remote' do
 
   license 'MIT'
 
-  self.extra_deps << ['cartage', '~> 1.0']
+  self.extra_deps << ['cartage', '~> 1.1']
+  self.extra_deps << ['micromachine', '~> 1.2']
   self.extra_deps << ['fog', '~> 1.27']
 
   self.extra_dev_deps << ['rake', '~> 10.0']
@@ -28,7 +29,6 @@ spec = Hoe.spec 'cartage-remote' do
   self.extra_dev_deps << ['hoe-gemspec2', '~> 1.1']
   self.extra_dev_deps << ['hoe-git', '~> 1.5']
   self.extra_dev_deps << ['hoe-geminabox', '~> 0.3']
-=begin
   self.extra_dev_deps << ['minitest', '~> 5.4']
   self.extra_dev_deps << ['minitest-autotest', '~> 1.0']
   self.extra_dev_deps << ['minitest-bisect', '~> 1.2']
@@ -36,10 +36,8 @@ spec = Hoe.spec 'cartage-remote' do
   self.extra_dev_deps << ['minitest-moar', '~> 0.0']
   self.extra_dev_deps << ['minitest-pretty_diff', '~> 0.1']
   self.extra_dev_deps << ['simplecov', '~> 0.7']
-=end
 end
 
-=begin
 namespace :test do
   task :coverage do
     prelude = <<-EOS
@@ -51,6 +49,5 @@ gem 'minitest'
     Rake::Task['test'].execute
   end
 end
-=end
 
 # vim: syntax=ruby

--- a/cartage-remote.gemspec
+++ b/cartage-remote.gemspec
@@ -1,14 +1,14 @@
 # -*- encoding: utf-8 -*-
-# stub: cartage-remote 1.0 ruby lib
+# stub: cartage-remote 1.1 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "cartage-remote"
-  s.version = "1.0"
+  s.version = "1.1"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]
   s.authors = ["Austin Ziegler"]
-  s.date = "2015-03-22"
+  s.date = "2015-03-26"
   s.description = "cartage-remote is a plug-in for {cartage}[https://github.com/KineticCafe/cartage]\nto build a package on a remote machine with cartage.\n\nCartage provides a repeatable means to create a package for a Rails application\nthat can be used in deployment with a configuration tool like Ansible, Chef,\nPuppet, or Salt. The package is created with its dependencies bundled in\n`vendor/bundle`, so it can be deployed in environments with strict access\ncontrol rules and without requiring development tool access."
   s.email = ["aziegler@kineticcafe.com"]
   s.extra_rdoc_files = ["Contributing.rdoc", "History.rdoc", "Licence.rdoc", "Manifest.txt", "README.rdoc", "Contributing.rdoc", "History.rdoc", "Licence.rdoc", "README.rdoc"]
@@ -23,7 +23,8 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<cartage>, ["~> 1.0"])
+      s.add_runtime_dependency(%q<cartage>, ["~> 1.1"])
+      s.add_runtime_dependency(%q<micromachine>, ["~> 1.2"])
       s.add_runtime_dependency(%q<fog>, ["~> 1.27"])
       s.add_development_dependency(%q<minitest>, ["~> 5.5"])
       s.add_development_dependency(%q<rdoc>, ["~> 4.0"])
@@ -32,9 +33,16 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<hoe-gemspec2>, ["~> 1.1"])
       s.add_development_dependency(%q<hoe-git>, ["~> 1.5"])
       s.add_development_dependency(%q<hoe-geminabox>, ["~> 0.3"])
+      s.add_development_dependency(%q<minitest-autotest>, ["~> 1.0"])
+      s.add_development_dependency(%q<minitest-bisect>, ["~> 1.2"])
+      s.add_development_dependency(%q<minitest-focus>, ["~> 1.1"])
+      s.add_development_dependency(%q<minitest-moar>, ["~> 0.0"])
+      s.add_development_dependency(%q<minitest-pretty_diff>, ["~> 0.1"])
+      s.add_development_dependency(%q<simplecov>, ["~> 0.7"])
       s.add_development_dependency(%q<hoe>, ["~> 3.13"])
     else
-      s.add_dependency(%q<cartage>, ["~> 1.0"])
+      s.add_dependency(%q<cartage>, ["~> 1.1"])
+      s.add_dependency(%q<micromachine>, ["~> 1.2"])
       s.add_dependency(%q<fog>, ["~> 1.27"])
       s.add_dependency(%q<minitest>, ["~> 5.5"])
       s.add_dependency(%q<rdoc>, ["~> 4.0"])
@@ -43,10 +51,17 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<hoe-gemspec2>, ["~> 1.1"])
       s.add_dependency(%q<hoe-git>, ["~> 1.5"])
       s.add_dependency(%q<hoe-geminabox>, ["~> 0.3"])
+      s.add_dependency(%q<minitest-autotest>, ["~> 1.0"])
+      s.add_dependency(%q<minitest-bisect>, ["~> 1.2"])
+      s.add_dependency(%q<minitest-focus>, ["~> 1.1"])
+      s.add_dependency(%q<minitest-moar>, ["~> 0.0"])
+      s.add_dependency(%q<minitest-pretty_diff>, ["~> 0.1"])
+      s.add_dependency(%q<simplecov>, ["~> 0.7"])
       s.add_dependency(%q<hoe>, ["~> 3.13"])
     end
   else
-    s.add_dependency(%q<cartage>, ["~> 1.0"])
+    s.add_dependency(%q<cartage>, ["~> 1.1"])
+    s.add_dependency(%q<micromachine>, ["~> 1.2"])
     s.add_dependency(%q<fog>, ["~> 1.27"])
     s.add_dependency(%q<minitest>, ["~> 5.5"])
     s.add_dependency(%q<rdoc>, ["~> 4.0"])
@@ -55,6 +70,12 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<hoe-gemspec2>, ["~> 1.1"])
     s.add_dependency(%q<hoe-git>, ["~> 1.5"])
     s.add_dependency(%q<hoe-geminabox>, ["~> 0.3"])
+    s.add_dependency(%q<minitest-autotest>, ["~> 1.0"])
+    s.add_dependency(%q<minitest-bisect>, ["~> 1.2"])
+    s.add_dependency(%q<minitest-focus>, ["~> 1.1"])
+    s.add_dependency(%q<minitest-moar>, ["~> 0.0"])
+    s.add_dependency(%q<minitest-pretty_diff>, ["~> 0.1"])
+    s.add_dependency(%q<simplecov>, ["~> 0.7"])
     s.add_dependency(%q<hoe>, ["~> 3.13"])
   end
 end


### PR DESCRIPTION
- Ensure remote script failures return a non-zero exit code. Fixes #1.
- Provide the exception error message to the postbuild script.
- Use micromachine [micromachine](https://github.com/soveran/micromachine) to
  provide the remote builds state machine cleanly.
